### PR TITLE
feat: editArticle 페이지 구현 작업

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { RecoilRoot } from 'recoil'
 
 import Footer from './Layout/Footer'
 import Header from './Layout/Header'
+import Article from './pages/Article'
 import CreateArticle from './pages/CreateArticle'
 import Home from './pages/Home'
 import Login from './pages/Login'
@@ -32,6 +33,14 @@ const App = () => {
         <Route
           path="/editor"
           element={<CreateArticle />}
+        />
+        <Route
+          path="/editor/:slug"
+          element={<CreateArticle />}
+        />
+        <Route
+          path="/article/:slug"
+          element={<Article />}
         />
         <Route
           path="/settings"

--- a/src/Layout/Header.tsx
+++ b/src/Layout/Header.tsx
@@ -40,8 +40,11 @@ const Header = () => {
             </li>
             <li className="nav-item">
               <Link
-                className={`nav-link ${location.pathname === '/editor' ? 'active' : null}`}
+                className={`nav-link ${location.pathname.includes('/editor') ? 'active' : null}`}
                 to="/editor"
+                onClick={(e) => {
+                  if (location.pathname.includes('/editor')) e.preventDefault()
+                }}
               >
                 {' '}
                 <i className="ion-compose"></i>&nbsp;New Article{' '}

--- a/src/components/ArticleItem.tsx
+++ b/src/components/ArticleItem.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { Link } from 'react-router-dom'
+
 import { GetArticleResponse } from '../Types/articles'
 
 type MyArticlesProps = {
@@ -42,14 +44,14 @@ const ArticleItem = ({ articles }: MyArticlesProps) => {
                 <i className="ion-heart"></i> {article.favoritesCount}
               </button>
             </div>
-            <a
-              href=""
+            <Link
+              to={`/article/${article.slug}`}
               className="preview-link"
             >
               <h1>{article.title}</h1>
               <p>{article.description}</p>
               <span>Read more...</span>
-            </a>
+            </Link>
           </div>
         ))}
     </div>


### PR DESCRIPTION
## 개요

- 어떤 기능을 처리했는지 작성 해주세요
- [x] 게시글 수정 로직 구현

## 작업사항

- 어떻게 처리했는지 작성 해주세요
- [x] slug값으로 해당 게시글의 정보를 가져와서 데이터를 보여주도록 구현
- [x] 게시글 수정 페이지에 있는 경우 Nav바에서 New Articles로 못넘어가도록 구현
- [x] 게시글 수정 완료 버튼을 누르면 게시글 정보가 업데이트 되도록 axios를 이용해 api 연결
- [x] 게시글 수정에 422 에러가 발생할 경우 error 메시지 출력
- [x] 게시글 수정 완료 후 게시글 상세페이지로 이동
